### PR TITLE
fix: Set file extensions for package entry files

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,12 +2,13 @@
   "name": "@nextcloud/initial-state",
   "version": "2.0.0",
   "description": "Access data from the nextcloud server-side initial state API within apps.",
-  "main": "dist/index.js",
-  "module": "dist/index.esm.js",
+  "type": "module",
+  "main": "dist/index.cjs",
   "types": "dist/index.d.ts",
   "exports": {
-    "import": "./dist/index.esm.js",
-    "require": "./dist/index.js"
+    "import": "./dist/index.es.mjs",
+    "require": "./dist/index.cjs",
+    "types": "./dist/index.d.ts"
   },
   "files": [
     "dist/"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,7 +11,7 @@ export default [
     ],
     output: [
       {
-        dir: 'dist',
+        file: 'dist/index.cjs',
         format: 'cjs',
         sourcemap: true,
       },
@@ -22,7 +22,7 @@ export default [
     plugins: [typescript()],
     output: [
       {
-        file: 'dist/index.esm.js',
+        file: 'dist/index.es.mjs',
         format: 'esm',
         sourcemap: true,
       },


### PR DESCRIPTION
If the package type is CommonJS all `.js` files will be handled as if they are CommonJS, even if exports is set to module. Same if type is set to ESM, then all `.js` files are handled as if they are modules. So the file extension has to be set to the explicit type.