### PR TITLE
Prepare 2.1.0 - Fixing Typescript exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ All notable changes to this project will be documented in this file.
 
 ## 1.2.0 - 2020-04-06
 ### Added
-- Add optional fallback parameter to laodState method
+- Add optional fallback parameter to loadState method
 
 ## 1.1.2 - 2020-04-06
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.1.0 - 2023-07-23
+### Fixed
+- Set explicit file extensions for package entry files to allow usage with `module` packages \([\#513](https://github.com/nextcloud/nextcloud-initial-state/pull/513)\)
+- Fix package exports to support Typescript projects with module resolution of `node16` or `nodenext` \([\#543](https://github.com/nextcloud/nextcloud-initial-state/pull/543)\)
+
+### Changed
+- Dependency updates
+
 ## 2.0.0 - 2022-08-23
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/initial-state",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/initial-state",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "GPL-3.0-or-later",
       "devDependencies": {
         "@rollup/plugin-typescript": "^11.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/initial-state",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Access data from the nextcloud server-side initial state API within apps.",
   "type": "module",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## 2.1.0 - 2023-07-23
### Fixed
- Set explicit file extensions for package entry files to allow usage with `module` packages \([\#513](https://github.com/nextcloud/nextcloud-initial-state/pull/513)\)
- Fix package exports to support Typescript projects with module resolution of `node16` or `nodenext` \([\#543](https://github.com/nextcloud/nextcloud-initial-state/pull/543)\)

### Changed
- Dependency updates