### PR TITLE
chore: adjust `engines` versions to support wider range

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,8 +21,7 @@
         "vitest": "^3.2.4"
       },
       "engines": {
-        "node": "^20.0.0",
-        "npm": "^10.0.0"
+        "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,20 @@
     "vitest": "^3.2.4"
   },
   "engines": {
-    "node": "^20.0.0",
-    "npm": "^10.0.0"
+    "node": "^20.0.0 || ^22.0.0 || ^24.0.0"
+  },
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "version": "^22.0.0",
+      "onFail": "error"
+    },
+    "packageManager": [
+      {
+        "name": "npm",
+        "version": "^10.5.0",
+        "onFail": "error"
+      }
+    ]
   }
 }


### PR DESCRIPTION
This library is used by multiple apps also supporting wide range of Nextcloud versions, thus we need to support the current Node version (22) as well as the one used by the oldest maintained Nextcloud version (Nextcloud 30 = Node 20).
Future proof we also support Node 24 - as this package is a browser library and not a NodeJS library its fine!

Move package manager to `devEngines` as its not a runtime requirement.